### PR TITLE
#153976050 view count should increase once for recipe owner

### DIFF
--- a/tests/test.js
+++ b/tests/test.js
@@ -829,6 +829,21 @@ describe('More Recipes', () => {
             done();
           });
       });
+    it('should allow another user to get a single recipe in the catalog',
+      (done) => {
+        server
+          .get(`/api/v1/recipes/${recipeId2}`)
+          .set('Connection', 'keep alive')
+          .set('Accept', 'application/json')
+          .set('x-access-token', userToken[1])
+          .set('Content-Type', 'application/json')
+          .end((err, res) => {
+            expect(res.statusCode).to.equal(200);
+            expect(res.body.status).to.equal('Success');
+            expect(res.body.message).to.equal('Recipe retrieved');
+            done();
+          });
+      });
     it('should return 400 if the recipeId parameter is not integer', (done) => {
       server
         .get('/api/v1/recipes/recipeId2')


### PR DESCRIPTION
#### What does this PR do?
Fix error with recipe view count increasing more than once for the owner of the recipe
#### Description of Task to be completed?
Recipe view count should increase when any user views the recipe but the view count should only count once for the recipe owner
#### How should this be manually tested?
- Clone the repository and change directory into it
- Install the dependencies with the command `npm install`
- Start the server with the command `npm run start:dev`
- Test the following api endpoint with postman `GET: api/v1/recipes/:recipeId`
#### What are the relevant pivotal tracker stories?
#153976050