### PR TITLE
#154700890 include recipe owner's name when fetching user's favorite recipes

### DIFF
--- a/server/controllers/favorite.js
+++ b/server/controllers/favorite.js
@@ -64,24 +64,26 @@ class FavoriteController {
    * @memberof FavoriteController
    */
   static userFavorites(req, res) {
-    return User
-      .findById(req.params.userId, {
-        attributes: ['firstName', 'lastName'],
+    return Favorite
+      .findAll({
+        attributes: ['userId', 'category'],
+        where: {
+          userId: req.params.userId,
+        },
         include: [{
-          model: Favorite,
-          attributes: ['recipeId', 'category'],
+          model: Recipe,
+          attributes: [
+            'id', 'title', 'category', 'description', 'preparationTime',
+            'ingredients', 'directions', 'recipeImage', 'upvotes',
+            'downvotes', 'views', 'favorites'],
           include: [{
-            model: Recipe,
-            attributes: [
-              'id', 'title', 'category', 'description', 'preparationTime',
-              'ingredients', 'directions', 'recipeImage', 'upvotes',
-              'downvotes', 'views', 'favorites'
-            ]
+            model: User,
+            attributes: ['firstName', 'lastName'],
           }]
-        }],
+        }]
       })
-      .then((user) => {
-        if (user.Favorites.length === 0) {
+      .then((favorites) => {
+        if (favorites.length === 0) {
           return res.status(404).send({
             status: 'Fail',
             message: 'User has not favorited any recipe',
@@ -91,7 +93,7 @@ class FavoriteController {
           status: 'Success',
           message: 'Favorites retrieved',
           data: {
-            user
+            favorites,
           }
         });
       })


### PR DESCRIPTION
#### What does this PR do?
Have recipe owners name included when fetching user's favorite recipes
#### Description of Task to be completed?
Recipe owners name should be included when fetching the recipes that were favorited by a user
#### How should this be manually tested?
- Clone the repository and change directory into it
- Install the dependencies with the command `npm install`
- Start the server with the command `npm run start:dev`
- Test the following API endpoint with postman `GET: api/v1/users/:userId/recipes`
#### Any background context you want to provide?
N/A
#### What are the relevant pivotal tracker stories?
#154700890
#### Screenshots (if appropriate)
<img width="1440" alt="screen shot 2018-01-27 at 8 45 21 pm" src="https://user-images.githubusercontent.com/28486643/35475725-0b49c0a0-03a3-11e8-9f8c-1a5cdd141d36.png">

#### Questions:
N/A